### PR TITLE
Updating documentation to reflect bug 54166

### DIFF
--- a/lib/DateTime/Event/Recurrence.pm
+++ b/lib/DateTime/Event/Recurrence.pm
@@ -1106,15 +1106,15 @@ C<DateTime::Event::ICal> module, for generating RFC2445 recurrences.
 The C<week_start_day> represents how the 'first week' of a period is
 calculated:
 
-"mo" - this is the default.  The first week is one that starts in
-Monday, and has I<the most days> in this period.
+Defaults to "1mo"
+Yearly recurrences default to "mo" (C<yearly()>)
 
-"tu", "we", "th", "fr", "sa", "su" - The first week is one that starts
-in this week-day, and has I<the most days> in this period.  Works for
+"mo", "tu", "we", "th", "fr", "sa", "su" - The first week is one that starts
+on this week-day, and has I<the most days> in this period.  Works for
 C<weekly> and C<yearly> recurrences.
 
-"1tu", "1we", "1th", "1fr", "1sa", "1su" - The first week is one that
-starts in this week-day, and has I<all days> in this period.  This
+"1mo", "1tu", "1we", "1th", "1fr", "1sa", "1su" - The first week is one that
+starts on this week-day, and has I<all days> in this period.  This
 works for C<weekly()>, C<monthly()> and C<yearly()> recurrences.
 
 =head2 Time Zones


### PR DESCRIPTION
The bug reported here:
https://rt.cpan.org/Public/Bug/Display.html?id=54166

Is caused by the assumption that the week_start_day defaults to 'mo', when it actually always defaults to 'mo1' unless you are doing a yearly lookup. 

Because this default has been in place for several years, changing the default now seems like a bad idea, due to people relying on this remaining the default. 

Instead, I've updated the documentation to show what the actual default is, as well as updated some of the wording. 
